### PR TITLE
Add users_cron_allow variable to manage cron permissions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ users_ssh_key_directory: ssh_keys
 # The default shell if not overwritten.
 users_shell: /bin/bash
 
+# manage cron permissions via /etc/cron.allow
+users_cron_allow: true
+
 # A list of groups and properties.
 # users_group_list:
 #   - name: robertdb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,3 +31,10 @@
   template:
     src: cron.allow.j2
     dest: /etc/cron.allow
+  when: users_cron_allow|bool
+
+- name: check existence of /etc/cron.allow
+  file:
+    path: /etc/cron.allow
+    state: absent
+  when: not users_cron_allow|bool


### PR DESCRIPTION
If users are deployed with this role, the file /etc/cron.allow is
created, even when `cron_allow` is unset. But if /etc/cron.allow exists,
only the users listed in that file are allowed to run cron. In other
word, if an empty `/etc/cron.allow` is created no user is allow to run
cron.

To disable the deployment of this file the variable users_cron_allow
should be set to 'false'.

Closes: robertdebock/ansible-role-users#5