### PR TITLE
Fixes /etc/cron.allow permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   ansible.builtin.template:
     src: cron.allow.j2
     dest: /etc/cron.allow
-    mode: "0640"
+    mode: "0644"
   when:
     - users_cron_allow | bool
 


### PR DESCRIPTION
Users cannot execute the `crontab` command if they cannot read `/etc/cron.allow`.

---
name: Pull request
about: See above

---

**Describe the change**
Permissions on `/etc/cron.allow`were changed from `0640` to `0644`.

**Testing**
In case a feature was added, how were tests performed?
None. Not needed.
