### PR TITLE
validate sudoers file

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -34,6 +34,7 @@
     src: sudo.j2
     dest: "/etc/sudoers.d/{{ user.name }}"
     mode: "0640"
+    validate: /usr/sbin/visudo -cf %s
   when:
     - user.sudo_options is defined
   loop_control:


### PR DESCRIPTION
Validate files in sudoers.d
---
name: Pull request
about: Validate files in /etc/sudoers.d/ before writing them.
---

**Describe the change**
Added validation of the templated changes to a sudoers.d-file.  This prevents locking yourself out of your server if there's a typo in your sudo_options.
The change is taken from the official documentation at https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html


**Testing**
Successfully converged the role with the change.
Failed as expected when passing bogus options for sudo.