### PR TITLE
Allow multiple sudo option lines per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
             - "https://raw.githubusercontent.com/shaanr/smdb/master/file.pub"
         - name: systemuser
           system: yes
+        - name: multisudo
+          sudo_options:
+            - "ALL= NOPASSWD: /usr/bin/systemctl restart httpd"
+            - "ALL= NOPASSWD: /usr/bin/systemctl start httpd"
+            - "ALL= NOPASSWD: /usr/bin/systemctl stop httpd"
 ```
 
 The machine needs to be prepared in CI this is done using `molecule/resources/prepare.yml`:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -48,3 +48,8 @@
             - "https://raw.githubusercontent.com/shaanr/smdb/master/file.pub"
         - name: systemuser
           system: yes
+        - name: multisudo
+          sudo_options:
+            - "ALL= NOPASSWD: /usr/bin/systemctl restart httpd"
+            - "ALL= NOPASSWD: /usr/bin/systemctl start httpd"
+            - "ALL= NOPASSWD: /usr/bin/systemctl stop httpd"

--- a/templates/sudo.j2
+++ b/templates/sudo.j2
@@ -1,2 +1,8 @@
 {{ ansible_managed | comment }}
+{% if user.sudo_options is iterable and user.sudo_options is not string %}
+{% for sudo_option in user.sudo_options %}
+{{ user.name }} {{ sudo_option }}
+{% endfor %}
+{% else %}
 {{ user.name }} {{ user.sudo_options }}
+{% endif %}


### PR DESCRIPTION
Allow multiple sudo option lines per user
---
name: Pull request
about: Extend the template so that users can specify multiple sudo option lines per user.

---

**Describe the change**
Allow the `sudo.j2` template to work with `sudo_options` being either a string like previous versions, or a list in case we need to define multiple sudo options for a single user. 

**Testing**
Tested by extending the current tests to test that the template generates a valid sudoers file for multiple sudo options (tests where already in place for a single option)
