### PR TITLE
fix nested loop when deploing multiple ssh keys for a user

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -97,15 +97,14 @@
     - user.manage_ssh_key is defined
     - user.manage_ssh_key
 
-- name: loop over authorized_keys for {{ user.name }}
-  ansible.builtin.include_tasks:
-    file: user_authorized_key.yml
+- name: Deploy authorized keys for {{ user.name }}
+  ansible.posix.authorized_key:
+    user: "{{ user.name }}"
+    state: present
+    key: "{{ item }}"
   loop: "{{ user.authorized_keys }}"
   loop_control:
     label: "{{ user.name }}"
-    loop_var: authorized_key
-  when:
-    - user.authorized_keys is defined
 
 - name: copy generated private ssh key for {{ user.name }}
   ansible.builtin.copy:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -105,6 +105,8 @@
   loop: "{{ user.authorized_keys }}"
   loop_control:
     label: "{{ user.name }}"
+  when:
+    - user.authorized_keys is defined
 
 - name: copy generated private ssh key for {{ user.name }}
   ansible.builtin.copy:

--- a/tasks/user_authorized_key.yml
+++ b/tasks/user_authorized_key.yml
@@ -1,9 +1,0 @@
----
-- name: place authorized_key for {{ user.name }}
-  ansible.posix.authorized_key:
-    user: "{{ user.name }}"
-    state: present
-    key: "{{ item }}"
-  loop: "{{ user.authorized_keys }}"
-  loop_control:
-    label: "{{ user.name }}"


### PR DESCRIPTION
---
name: Pull request
about: avoid nested loop when deploying multiple ssh keys for a user
---

Executing this playbook  task `place authorized_key for robertdb` is executed 6 times. The task is executed as many times as the length of `[authorized_keys]` . I tested it using `robertdebock.users` version `5.3.0` and `ansible-core-2.11.4`

```
---

- name: test users
  hosts: localhost
  gather_facts: true
  become: true


  tasks:

    - name: Just a test
      ansible.builtin.import_role:
        name: robertdebock.users
      vars:
        users_user_list:
          - name: robertdb
            comment: Robert de Bock
            authorized_keys:
              - "ssh-rsa ABC123"
              - "ssh-rsa ABadfasdfasdfjC123"
              - "ssh-rsa ABC1sdfasdfasdfasdf23"
              - "ssh-rsa ABC1sdfasdfasdfaskdsadfasdfkjdf23"
              - "ssh-rsa ABC1sdfadfiadfasdksdfasdfasdf23"
              - "ssh-rsa ABC1sdfasdfasdfasadfasdfkjhkjdf23"
```

This PR should fix it so the task deploying the keys is only executed once.
