### PR TITLE
Make role work well with usernames containing a '.' (dot) sign.

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -43,6 +43,25 @@
           # The value `-1` removes the expiry time.
           expires: -1
           password_validity_days: 9
+          # Test username with dots
+        - name: robert.d.b
+          comment: Robert de Bock with dots in username
+          uid: 102
+          # The `group` and `groups` listed here should exist.
+          group: robertdb
+          # groups: A comma separated string of groups, i.e.:
+          # groups: users,wheel
+          groups: users
+          cron_allow: yes
+          sudo_options: "ALL=(ALL) NOPASSWD: ALL"
+          # Adding an authorized key.
+          authorized_keys:
+            - "ssh-rsa ABC123"
+          # EPOCH timestamp when an account should expire.
+          # Typically a positive value like: `1641971487`.
+          # The value `-1` removes the expiry time.
+          expires: -1
+          password_validity_days: 9
         # Here a user is removed.
         - name: notuser
           state: absent

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -46,7 +46,7 @@
           # Test username with dots
         - name: robert.d.b
           comment: Robert de Bock with dots in username
-          uid: 102
+          uid: 1025
           # The `group` and `groups` listed here should exist.
           group: robertdb
           # groups: A comma separated string of groups, i.e.:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -42,7 +42,7 @@
 
 - name: remove sudo options for {{ user.name }}
   ansible.builtin.file:
-    path: "/etc/sudoers.d/{{ user.name | replace(".", "dot", 1)  }}"
+    path: '/etc/sudoers.d/{{ user.name | replace(".", "dot", 1)  }}'
     state: absent
   when:
     - user.sudo_options is not defined

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -32,7 +32,7 @@
 - name: set sudo options for {{ user.name }}
   ansible.builtin.template:
     src: sudo.j2
-    dest: '/etc/sudoers.d/{{ user.name | replace(".", "dot", 1) }}'
+    dest: '/etc/sudoers.d/{{ user.name | replace(".", "dot") }}'
     mode: "0640"
     validate: /usr/sbin/visudo -cf %s
   when:
@@ -42,7 +42,7 @@
 
 - name: remove sudo options for {{ user.name }}
   ansible.builtin.file:
-    path: '/etc/sudoers.d/{{ user.name | replace(".", "dot", 1)  }}'
+    path: '/etc/sudoers.d/{{ user.name | replace(".", "dot")  }}'
     state: absent
   when:
     - user.sudo_options is not defined

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -32,7 +32,7 @@
 - name: set sudo options for {{ user.name }}
   ansible.builtin.template:
     src: sudo.j2
-    dest: "/etc/sudoers.d/{{ user.name|replace(".", "dot", 1) }}"
+    dest: '/etc/sudoers.d/{{ user.name | replace(".", "dot", 1) }}'
     mode: "0640"
     validate: /usr/sbin/visudo -cf %s
   when:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -48,7 +48,7 @@
     - user.sudo_options is not defined
   loop_control:
     label: "{{ user.name }}"
-    
+
 - name: ensure the sudoers.d directory is checked for user sudoers files (will be put after EOF if not exists)
   ansible.builtin.lineinfile:
     path: /etc/sudoers

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -42,12 +42,18 @@
 
 - name: remove sudo options for {{ user.name }}
   ansible.builtin.file:
-    path: "/etc/sudoers.d/{{ user.name }}"
+    path: "/etc/sudoers.d/{{ user.name | replace(".", "dot", 1)  }}"
     state: absent
   when:
     - user.sudo_options is not defined
   loop_control:
     label: "{{ user.name }}"
+    
+- name: ensure the sudoers.d directory is checked for user sudoers files (will be put after EOF if not exists)
+  ansible.builtin.lineinfile:
+    path: /etc/sudoers
+    state: present 
+    line: '#includedir /etc/sudoers.d'
 
 - name: generate private ssh key for {{ user.name }}
   ansible.builtin.command:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -52,7 +52,7 @@
 - name: ensure the sudoers.d directory is checked for user sudoers files (will be put after EOF if not exists)
   ansible.builtin.lineinfile:
     path: /etc/sudoers
-    state: present 
+    state: present
     line: '#includedir /etc/sudoers.d'
 
 - name: generate private ssh key for {{ user.name }}

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -32,7 +32,7 @@
 - name: set sudo options for {{ user.name }}
   ansible.builtin.template:
     src: sudo.j2
-    dest: "/etc/sudoers.d/{{ user.name }}"
+    dest: "/etc/sudoers.d/{{ user.name|replace(".", "dot", 1) }}"
     mode: "0640"
     validate: /usr/sbin/visudo -cf %s
   when:


### PR DESCRIPTION
PR for #23 

---
name: Pull request
about: Making role work well with usernames containing a '.' (dot) sign.
Currently it doesn't work for such users.

---

**Describe the change**
It uses jinja filter to replace '.' signs to "dot" string in filename refering to username, so the sudo application won't ommit this file (which is by design of sudo (see sudoers(5) manual.

**Testing**
In case a feature was added, how were tests performed?
locally on rocky linux and debian. 
added a user into molecule converge.yaml config, pipeline testing