### PR TITLE
Speed up installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
   ansible.builtin.package:
     name: "{{ users_requirements }}"
     state: present
+  when: (users_requirements | length) > 0
 
 - name: Loop over users_groups
   ansible.builtin.include_tasks:


### PR DESCRIPTION
The variable "users_requirements" is an empty list by default.
The task will still needlessly check for updates though. Skipping this when it is not needed speeds up the playbook run.

---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
Add condition to skip "Install required software" if there is none to be installed.

**Testing**
Successfully ran the role without installing an empty list of packages.
