### PR TITLE
Add sudo support for Debian/stretch and Ubuntu/xenial

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,8 +19,10 @@ _users_sudo_includedir:
   default: "@includedir /etc/sudoers.d"
   Amazon: "#includedir /etc/sudoers.d"
   Debian:
+    xenial: "#includedir /etc/sudoers.d"
     focal: "#includedir /etc/sudoers.d"
     bionic: "#includedir /etc/sudoers.d"
+    stretch: "#includedir /etc/sudoers.d"
     buster: "#includedir /etc/sudoers.d"
   RedHat:
     "8": "#includedir /etc/sudoers.d"


### PR DESCRIPTION
Closes: robertdebock/ansible-role-users#38

---
name: Pull request
about: Add sudo support for Debian/stretch and Ubuntu/xenial

---

**Describe the change**
Add sudo support for Debian/stretch and Ubuntu/xenial

**Testing**
I **will** test the change locally against a Debian/stretch VM.