### PR TITLE
robertdebock.users: Add ansible.posix.authorized_key exclusive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
           # You can remove authorized keys.
           unauthorized_keys:
             - "ssh-rsa XYZYX54321"
+        - name: exclusive
+          # This key will be exclusive
+          authorized_keys:
+            - "ssh-rsa XYZYX54321"
+          exclusive_keys: true
         - name: robertdb
           comment: Robert de Bock
           uid: 1024

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -117,6 +117,7 @@
 - name: user | Deploy authorized keys for {{ user.name }}
   ansible.posix.authorized_key:
     user: "{{ user.name }}"
+    exclusive: "{{ user.exclusive_keys|default(false) }}"
     state: present
     key: "{{ item }}"
   loop: "{{ user.authorized_keys }}"


### PR DESCRIPTION
**Describe the change**

Added a new option `user.exclusive_keys` which allows to set the `exclusive` parameter of the ansible module `ansible.posix.authorized_key` :

Quoting ansible.posix.authorized_key module:
```
exclusive (boolean):

  Whether to remove all other non-specified keys from the authorized_keys
  file.

  Multiple keys can be specified in a single key string value by
  separating them by newlines.

  This option is not loop aware, so if you use with_ , it will be
  exclusive per iteration of the loop.

  If you want multiple keys in the file you need to pass them all to key
  in a single batch as mentioned above.

  Choices:

  * false (default)
  * true
```

This parameter has been tested locally in our environment.

Closes: #42 