### PR TITLE
Fix typo in "item.expires"

### DIFF
--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -165,7 +165,7 @@
     - users is defined
     - item.update_password is defined
 
-- name: assert | Test item.exipres in users
+- name: assert | Test item.expires in users
   ansible.builtin.assert:
     that:
       - item.expires is number


### PR DESCRIPTION
---
name: Pull request
about: Assertion typo

---

**Describe the change**
`item.expires` was spelled as `item.exipres`. This fixes it.

**Testing**
No testing needed
